### PR TITLE
Fix qmake.sh script for Qt 5.11

### DIFF
--- a/m4/qmake.m4
+++ b/m4/qmake.m4
@@ -42,6 +42,7 @@ if test -n "$QMAKE"; then
     echo 'cat $MAKEFILE | \
       sed "s/-arch@<:@\\@:>@* i386//g" | \
       sed "s/-arch@<:@\\@:>@* x86_64//g" | \
+      sed "s/-arch \$(arch)//g" | \
       sed "s/-arch//g" | \
       sed "s/-Xarch@<:@^ @:>@*//g" > $MAKEFILE.fixed && \
       mv $MAKEFILE.fixed $MAKEFILE' >> qmake.sh


### PR DESCRIPTION
I am working on building OpenModelica with homebrew ( work in progress at https://github.com/traversaro/homebrew-modelica/blob/master/Formula/OpenModelica.rb ) and homebrew currently ships Qt 5.11 . 

In Qt 5.11, the Makefile generated by qmake contain the following line:
~~~
EXPORT_ARCH_ARGS = $(foreach arch, $(if $(EXPORT_ACTIVE_ARCHS), $(EXPORT_ACTIVE_ARCHS), $(EXPORT_VALID_ARCHS)), -arch $(arch)) 
~~~
I am not sure what is the purpose of the `qmake.sh` script, but in its current form it removes just the `-arch` part of this line, and so the compilation of OMPlotGUI, OMEditGUI and all the other GUIs results in the following error: 
~~~
clang++ -c -I/usr/local/opt/gettext/include -std=c++11 -O2 -std=gnu++11   x86_64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -mmacosx-version-min=10.11 -w -fPIC -DQT_NO_DEBUG -DQT_SVG_LIB -DQT_PRINTSUPPORT_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -I../../../build/include/omplot/qwt -I../../../build/include/omc/c -I. -I/usr/local/Cellar/qt/5.11.0/lib/QtSvg.framework/Headers -I/usr/local/Cellar/qt/5.11.0/lib/QtPrintSupport.framework/Headers -I/usr/local/Cellar/qt/5.11.0/lib/QtWidgets.framework/Headers -I/usr/local/Cellar/qt/5.11.0/lib/QtGui.framework/Headers -I/usr/local/Cellar/qt/5.11.0/lib/QtCore.framework/Headers -I../generatedfiles/moc -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/OpenGL.framework/Headers -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/AGL.framework/Headers -I/usr/local/Cellar/qt/5.11.0/mkspecs/macx-clang -F/usr/local/Cellar/qt/5.11.0/lib -o Plot.o Plot.cpp
clang: error: no such file or directory: 'x86_64'
~~~

To strip the arch related flags, it is necessary to remove the "-arch $(arch)" part of the Makefile, as proposed in this PR. 