### PR TITLE
Include lib folder in RPATH_QMAKE

### DIFF
--- a/m4/omhome.m4
+++ b/m4/omhome.m4
@@ -21,13 +21,13 @@ elif test "$host" = "i586-pc-mingw32msvc"; then
   # Yes, we build static libs on Windows, so the "shared" extension is .a
   SHREXT=".a"
   RPATH="-Wl,-z,origin -Wl,-rpath,'\$\$ORIGIN/../lib/$host_short/omc' -Wl,-rpath,'\$\$ORIGIN'"
-  RPATH_QMAKE="-Wl,-z,origin -Wl,-rpath,\\'\\\$\$ORIGIN/../lib/$host_short/omc\\' -Wl,-rpath,\\'\\\$\$ORIGIN\\'"
+  RPATH_QMAKE="-Wl,-z,origin -Wl,-rpath,\\'\\\$\$ORIGIN/../lib/$host_short/omc\\' -Wl,-rpath,\\'\\\$\$ORIGIN/../lib\\' -Wl,-rpath,\\'\\\$\$ORIGIN\\'"
 else
   APP=""
   EXE=""
   SHREXT=".so"
   RPATH="-Wl,-z,origin -Wl,-rpath,'\$\$ORIGIN/../lib/$host_short/omc' -Wl,-rpath,'\$\$ORIGIN'"
-  RPATH_QMAKE="-Wl,-z,origin -Wl,-rpath,\\'\\\$\$ORIGIN/../lib/$host_short/omc\\' -Wl,-rpath,\\'\\\$\$ORIGIN\\'"
+  RPATH_QMAKE="-Wl,-z,origin -Wl,-rpath,\\'\\\$\$ORIGIN/../lib/$host_short/omc\\' -Wl,-rpath,\\'\\\$\$ORIGIN/../lib\\' -Wl,-rpath,\\'\\\$\$ORIGIN\\'"
 fi
 
 define(FIND_OPENMODELICAHOME, [


### PR DESCRIPTION
This is required for the OMSimulator libraries used by OMEdit.